### PR TITLE
made HipChat server configurable in plugin settings

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/HipChatNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/HipChatNotifier.java
@@ -128,6 +128,7 @@ public class HipChatNotifier extends Notifier {
     @Override
     public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
         PrintStream logger = listener.getLogger();
+        String server = getDescriptor().getServer();
         String token = getDescriptor().getToken();
 
         logger.println("HipChat Post   : " + shouldPost(build));
@@ -135,7 +136,7 @@ public class HipChatNotifier extends Notifier {
         logger.println("HipChat Notify : " + shouldNotify(build));
 
         if (token.length() > 0 && getRoom().length() > 0 && shouldPost(build)) {
-            boolean notifyResult = new HipChat(token).notify(
+            boolean notifyResult = new HipChat(token, server).notify(
                     getRoom(),
                     new NotifyMessage(
                             NotifyMessage.BackgroundColor.get(build.getResult().color),
@@ -166,6 +167,7 @@ public class HipChatNotifier extends Notifier {
     @Extension
     public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
         private static final String NOTIFY_TEMPLATE = "${JOB_NAME} #${BUILD_NUMBER} (${BUILD_RESULT}) ${BUILD_URL}";
+        private String server;
         private String token;
 
         /**
@@ -178,6 +180,10 @@ public class HipChatNotifier extends Notifier {
 
         public String getToken() {
             return token;
+        }
+        
+        public String getServer() {
+            return server;
         }
 
         public String getDefaultMessageFormat() {
@@ -214,6 +220,7 @@ public class HipChatNotifier extends Notifier {
 
         @Override
         public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+            this.server = json.getString("server");
             this.token = json.getString("token");
             save();
             return super.configure(req, json);

--- a/src/main/java/org/jenkinsci/plugins/hipchat/HipChat.java
+++ b/src/main/java/org/jenkinsci/plugins/hipchat/HipChat.java
@@ -19,17 +19,19 @@ import java.nio.charset.Charset;
  * To change this template use File | Settings | File Templates.
  */
 public class HipChat {
-    private static final String NOTIFY_URL = "https://api.hipchat.com/v2/room/%s/notification?auth_token=%s"; // TODO: config
+    private static final String NOTIFY_URL = "%s/v2/room/%s/notification?auth_token=%s";
     private final String token;
+    private final String server;
 
-    public HipChat(String token) {
+    public HipChat(String token, String server) {
         this.token = token;
+        this.server = server;
     }
 
     public boolean notify(String room, NotifyMessage message) {
         try {
             CloseableHttpClient client = HttpClients.createDefault();
-            HttpPost post = new HttpPost(String.format(NOTIFY_URL, encode(room), encode(this.token)));
+            HttpPost post = new HttpPost(String.format(NOTIFY_URL, this.server, encode(room), encode(this.token)));
             post.setEntity(new StringEntity(message.toJson().toString(), ContentType.create("application/json", Charset.defaultCharset())));
             CloseableHttpResponse res = client.execute(post);
 

--- a/src/main/resources/org/jenkinsci/plugins/HipChatNotifier/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/HipChatNotifier/global.jelly
@@ -14,7 +14,7 @@
   <f:section title="Hip Chat Notifier">
     <f:entry title="Server" field="server"
       description="HipChat API Server, e.g. https://api.hipchat.com">
-      <f:textbox />
+      <f:textbox default="https://api.hipchat.com" />
     </f:entry>
     <f:entry title="API Token" field="token"
       description="HipChat API Token">

--- a/src/main/resources/org/jenkinsci/plugins/HipChatNotifier/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/HipChatNotifier/global.jelly
@@ -12,6 +12,10 @@
     so it should be straightforward to find them.
   -->
   <f:section title="Hip Chat Notifier">
+    <f:entry title="Server" field="server"
+      description="HipChat API Server, e.g. https://api.hipchat.com">
+      <f:textbox />
+    </f:entry>
     <f:entry title="API Token" field="token"
       description="HipChat API Token">
       <f:textbox />

--- a/src/main/resources/org/jenkinsci/plugins/HipChatNotifier/help-server.html
+++ b/src/main/resources/org/jenkinsci/plugins/HipChatNotifier/help-server.html
@@ -1,0 +1,4 @@
+<div>
+    Your HipChat API server,<br>
+    e.g. <i>https://api.hipchat.com</i>.
+</div>


### PR DESCRIPTION
This change adds a new option in the plugin's settings to specify the HipChat server. Without this option only Atlassian-hosted HipChat users can use this plugin.

This solves a TODO in HipChat.java!
